### PR TITLE
Declare alphaOffset before assignment

### DIFF
--- a/lib/canvas_resize.js
+++ b/lib/canvas_resize.js
@@ -98,7 +98,7 @@
 
           a = (data[offset + 3] / 255);
 
-          alphaOffset = targetOffset / 4;
+          var alphaOffset = targetOffset / 4;
 
           if (extraX) {
 


### PR DESCRIPTION
Prevents `Uncaught ReferenceError: alphaOffset is not defined`, which started appearing in Chromium. For some reason, this error wasn't being thrown until just recently, although I've been using Limby for a few weeks now.
