### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ limby-resize
 Wrapper for both.
 
 
-####Better resizing with `canvas`
+#### Better resizing with `canvas`
 
 Normally, resizing with `canvas` produces some not so great images.  This module implements it's own resizing algorithm.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
